### PR TITLE
Python3 import fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 coverage==3.7.1
 mock
 nose
+six
 sure<1.2.4

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
             'uncurl = uncurl.bin:main',
         ],
     },
-    install_requires=['xerox'],
+    install_requires=['xerox', 'six'],
     packages=find_packages(exclude=("tests", "tests.*")),
 )

--- a/uncurl/api.py
+++ b/uncurl/api.py
@@ -1,7 +1,7 @@
 import argparse
 from collections import OrderedDict
-import Cookie
 import json
+from six.moves import http_cookies as Cookie
 import shlex
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
This fixes a small import issue in Python3 since `Cookie` was moved in Python 3. For backwards compatibility using `six`.