### PR TITLE
feature(uncurl/api.py): Add recognizing the --user and -u

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,17 +8,19 @@ def test_basic_get():
         """requests.get("https://pypi.python.org/pypi/uncurl",
     headers={},
     cookies={},
+    auth=(),
 )"""
     )
 
 
 def test_colon_header():
-    uncurl.parse("curl 'https://pypi.python.org/pypi/uncurl' -H ':authority:mobile.twitter.com'").should.equal(
+    uncurl.parse("curl 'https://pypi.python.org/pypi/uncurl' -H 'authority:mobile.twitter.com'").should.equal(
         """requests.get("https://pypi.python.org/pypi/uncurl",
     headers={
-        ":authority": "mobile.twitter.com"
+        "authority": "mobile.twitter.com"
     },
     cookies={},
+    auth=(),
 )"""
     )
 
@@ -31,6 +33,7 @@ def test_basic_headers():
         "Accept-Language": "en-US,en;q=0.8"
     },
     cookies={},
+    auth=(),
 )"""
     )
 
@@ -45,6 +48,7 @@ def test_cookies():
         "baz": "baz2",
         "foo": "bar"
     },
+    auth=(),
 )"""
     )
 
@@ -59,6 +63,7 @@ def test_cookies_lowercase():
         "baz": "baz2",
         "foo": "bar"
     },
+    auth=(),
 )"""
     )
 
@@ -71,6 +76,7 @@ def test_cookies_dollar_sign():
     cookies={
         "somereallyreallylongcookie": "true"
     },
+    auth=(),
 )"""
     )
 
@@ -85,6 +91,7 @@ def test_post():
         "baz": "baz2",
         "foo": "bar"
     },
+    auth=(),
 )"""
     )
 
@@ -100,6 +107,7 @@ def test_post_with_dict_data():
         "baz": "baz2",
         "foo": "bar"
     },
+    auth=(),
 )"""
     )
 
@@ -110,6 +118,7 @@ def test_post_with_string_data():
     data='this is just some data',
     headers={},
     cookies={},
+    auth=(),
 )"""
     )
 
@@ -120,6 +129,7 @@ def test_parse_curl_with_binary_data():
     data='this is just some data',
     headers={},
     cookies={},
+    auth=(),
 )"""
     )
 
@@ -147,6 +157,7 @@ def test_parse_curl_with_another_binary_data():
         "User-Agent": "Mozilla/5.0 (Linux; Android 6.0.1; OPPO R9s Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 hap/1.0/oppo com.nearme.instant.platform/2.1.0beta1 com.felink.quickapp.reader/1.0.3 ({\"packageName\":\"com.oppo.market\",\"type\":\"other\",\"extra\":{}})"
     },
     cookies={},
+    auth=(),
 )""")
 
 
@@ -155,6 +166,7 @@ def test_parse_curl_with_insecure_flag():
         """requests.get("https://pypi.python.org/pypi/uncurl",
     headers={},
     cookies={},
+    auth=(),
     verify=False
 )"""
     )
@@ -168,6 +180,7 @@ def test_parse_curl_with_request_kargs():
         "Accept-Encoding": "gzip,deflate,sdch"
     },
     cookies={},
+    auth=(),
 )""")
                       
     uncurl.parse("curl 'https://pypi.python.org/pypi/uncurl' -H 'Accept-Encoding: gzip,deflate,sdch'", timeout=0.1).should.equal("""requests.get("https://pypi.python.org/pypi/uncurl",
@@ -176,6 +189,7 @@ def test_parse_curl_with_request_kargs():
         "Accept-Encoding": "gzip,deflate,sdch"
     },
     cookies={},
+    auth=(),
 )""")
                       
 

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -19,4 +19,5 @@ requests.get("https://pypi.python.org/pypi/uncurl",
         "Accept-Language": "en-US,en;q=0.8"
     },
     cookies={},
+    auth=(),
 )""")

--- a/uncurl/api.py
+++ b/uncurl/api.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import argparse
 import json
 import re
@@ -15,10 +16,11 @@ parser.add_argument('-X', default='')
 parser.add_argument('-H', '--header', action='append', default=[])
 parser.add_argument('--compressed', action='store_true')
 parser.add_argument('--insecure', action='store_true')
+parser.add_argument('--user', '-u', default=())
 
 BASE_INDENT = " " * 4
 
-ParsedContext = namedtuple('ParsedContext', ['method', 'url', 'data', 'headers', 'cookies', 'verify'])
+ParsedContext = namedtuple('ParsedContext', ['method', 'url', 'data', 'headers', 'cookies', 'verify', 'auth'])
 
 def parse_context(curl_command):
     method = "get"
@@ -50,13 +52,19 @@ def parse_context(curl_command):
         else:
             quoted_headers[header_key] = header_value.strip()
 
+    # add auth
+    user = parsed_args.user
+    if parsed_args.user:
+        user = tuple(user.split(':'))
+
     return ParsedContext(
         method=method,
         url=parsed_args.url,
         data=post_data,
         headers=quoted_headers,
         cookies=cookie_dict,
-        verify=parsed_args.insecure
+        verify=parsed_args.insecure,
+        auth=user
     )
 
 
@@ -74,7 +82,10 @@ def parse(curl_command, **kargs):
     requests_kargs=''
     for k,v in sorted(kargs.items()):
         requests_kargs += "{}{}={},\n".format(BASE_INDENT,k,str(v))
-        
+
+    #auth_data = f'{BASE_INDENT}auth={parsed_context.auth}'
+    auth_data = "{}auth={}".format(BASE_INDENT,parsed_context.auth)
+
     formatter = {
         'method': parsed_context.method,
         'url': parsed_context.url,
@@ -82,13 +93,16 @@ def parse(curl_command, **kargs):
         'headers_token': "{}headers={}".format(BASE_INDENT, dict_to_pretty_string(parsed_context.headers)),
         'cookies_token': "{}cookies={}".format(BASE_INDENT, dict_to_pretty_string(parsed_context.cookies)),
         'security_token': verify_token,
-        'requests_kargs': requests_kargs
+        'requests_kargs': requests_kargs,
+        'auth': auth_data
     }
 
     return """requests.{method}("{url}",
 {requests_kargs}{data_token}{headers_token},
 {cookies_token},{security_token}
+{auth}
 )""".format(**formatter)
+
 
 def dict_to_pretty_string(the_dict, indent=4):
     if not the_dict:
@@ -96,3 +110,4 @@ def dict_to_pretty_string(the_dict, indent=4):
 
     return ("\n" + " " * indent).join(
         json.dumps(the_dict, sort_keys=True, indent=indent, separators=(',', ': ')).splitlines())
+

--- a/uncurl/api.py
+++ b/uncurl/api.py
@@ -99,8 +99,8 @@ def parse(curl_command, **kargs):
 
     return """requests.{method}("{url}",
 {requests_kargs}{data_token}{headers_token},
-{cookies_token},{security_token}
-{auth}
+{cookies_token},
+{auth},{security_token}
 )""".format(**formatter)
 
 


### PR DESCRIPTION
We add a feature ,it can recognize curl (--user/-u) parameter
example:

```
curl http://host   -u name:password
####
requests.get("http://host",
    headers={},
    cookies={},
    auth=('name', 'password')
)
####
curl 'https://pypi.python.org/pypi/uncurl' --data '{"evt":"newsletter.show","properties":{"newsletter_type":"userprofile"}}' -H 'Accept-Encoding: gzip,deflate,sdch' -H 'Cookie: foo=bar; baz=baz2'
####
requests.post("https://pypi.python.org/pypi/uncurl",
    data='{"evt":"newsletter.show","properties":{"newsletter_type":"userprofile"}}',
    headers={
        "Accept-Encoding": "gzip,deflate,sdch"
    },
    cookies={
        "baz": "baz2",
        "foo": "bar"
    },
    auth=()
)
```
