### PR TITLE
normalize excaped multilines

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -201,6 +201,18 @@ def test_parse_curl_with_request_kargs():
     auth=(),
 )""")
                       
+def test_parse_curl_with_escaped_newlines():
+    uncurl.parse("""curl 'https://pypi.python.org/pypi/uncurl' \\\n -H 'Accept-Encoding: gzip,deflate' \\\n --insecure""").should.equal(
+        """requests.get("https://pypi.python.org/pypi/uncurl",
+    headers={
+        "Accept-Encoding": "gzip,deflate"
+    },
+    cookies={},
+    auth=(),
+    verify=False
+)"""
+    )
+
 
 
 if __name__ == '__main__':

--- a/uncurl/api.py
+++ b/uncurl/api.py
@@ -24,10 +24,15 @@ BASE_INDENT = " " * 4
 
 ParsedContext = namedtuple('ParsedContext', ['method', 'url', 'data', 'headers', 'cookies', 'verify', 'auth'])
 
+
+def normalize_newlines(multiline_text):
+    return multiline_text.replace(" \\\n", " ")
+
+
 def parse_context(curl_command):
     method = "get"
 
-    tokens = shlex.split(curl_command)
+    tokens = shlex.split(normalize_newlines(curl_command))
     parsed_args = parser.parse_args(tokens)
 
     post_data = parsed_args.data or parsed_args.data_binary


### PR DESCRIPTION
When copying the request from chrome, it may come as multiline text with an escaped newline (depending on the chrome version and the length of the text).