### PR TITLE
escaped unicode characters in cookies

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -212,6 +212,15 @@ def test_parse_curl_with_escaped_newlines():
     verify=False
 )"""
     )
+    
+def test_parse_curl_escaped_unicode_in_cookie():
+    uncurl.parse("""curl 'https://pypi.python.org/pypi/uncurl' -H $'cookie: sid=00Dt00000004XYz\\u0021ARg' """).should.equal("""requests.get("https://pypi.python.org/pypi/uncurl",
+    headers={},
+    cookies={
+        "sid": "00Dt00000004XYz!ARg"
+    },
+    auth=(),
+)""")
 
 
 

--- a/uncurl/api.py
+++ b/uncurl/api.py
@@ -53,7 +53,7 @@ def parse_context(curl_command):
             header_key, header_value = curl_header.split(":", 1)
 
         if header_key.lower().strip("$") == 'cookie':
-            cookie = Cookie.SimpleCookie(header_value)
+            cookie = Cookie.SimpleCookie(bytes(header_value, "ascii").decode("unicode-escape"))
             for key in cookie:
                 cookie_dict[key] = cookie[key].value
         else:


### PR DESCRIPTION
If cookie contains some unicode characters then chrome escapes them something like ` \u0021`.