### PR TITLE
raise exception instead of printing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ coverage==5.5
 mock
 nose
 six
+pyperclip
 sure<1.2.4

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='uncurl',
-    version='0.0.11',
-    description='A library to convert curl requests to python-requests.',
-    author='Steve Pulec',
-    author_email='spulec@gmail.com',
-    url='https://github.com/spulec/uncurl',
+    name='uncurl-pk',
+    version='0.0.2',
+    description='A library to convert curl requests to python-requests. Forked version of spulec/uncurl ',
+    author='Pankaj Kumar',
+    author_email='pnkjpvt@gmail.com',
+    url='https://github.com/pnkjkpvt/uncurl/tree/master',
     entry_points={
         'console_scripts': [
             'uncurl = uncurl.bin:main',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='uncurl-pk',
-    version='0.0.2',
+    version='0.0.4',
     description='A library to convert curl requests to python-requests. Forked version of spulec/uncurl ',
     author='Pankaj Kumar',
     author_email='pnkjpvt@gmail.com',

--- a/uncurl/api.py
+++ b/uncurl/api.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import argparse
 import json
 import re
 import shlex
@@ -7,7 +6,9 @@ from collections import OrderedDict, namedtuple
 
 from six.moves import http_cookies as Cookie
 
-parser = argparse.ArgumentParser()
+from .argparser import ArgumentParser
+
+parser = ArgumentParser()
 parser.add_argument('command')
 parser.add_argument('url')
 parser.add_argument('-d', '--data')

--- a/uncurl/api.py
+++ b/uncurl/api.py
@@ -1,14 +1,21 @@
 # -*- coding: utf-8 -*-
+import argparse
 import json
 import re
 import shlex
 from collections import OrderedDict, namedtuple
 
 from six.moves import http_cookies as Cookie
+from typing_extensions import override
 
-from .argparser import ArgumentParser
 
-parser = ArgumentParser()
+class ModifiedArgumentParser(argparse.ArgumentParser):
+    @override
+    def error(self, message):
+        raise ValueError(message)
+
+
+parser = ModifiedArgumentParser()
 parser.add_argument('command')
 parser.add_argument('url')
 parser.add_argument('-d', '--data')
@@ -16,10 +23,10 @@ parser.add_argument('-b', '--data-binary', '--data-raw', default=None)
 parser.add_argument('-X', default='')
 parser.add_argument('-H', '--header', action='append', default=[])
 parser.add_argument('--compressed', action='store_true')
-parser.add_argument('-k','--insecure', action='store_true')
+parser.add_argument('-k', '--insecure', action='store_true')
 parser.add_argument('--user', '-u', default=())
-parser.add_argument('-i','--include', action='store_true')
-parser.add_argument('-s','--silent', action='store_true')
+parser.add_argument('-i', '--include', action='store_true')
+parser.add_argument('-s', '--silent', action='store_true')
 parser.add_argument('-x', '--proxy', default={})
 parser.add_argument('-U', '--proxy-user', default='')
 
@@ -104,12 +111,12 @@ def parse(curl_command, **kargs):
     if parsed_context.verify:
         verify_token = '\n{}verify=False'.format(BASE_INDENT)
 
-    requests_kargs=''
-    for k,v in sorted(kargs.items()):
-        requests_kargs += "{}{}={},\n".format(BASE_INDENT,k,str(v))
+    requests_kargs = ''
+    for k, v in sorted(kargs.items()):
+        requests_kargs += "{}{}={},\n".format(BASE_INDENT, k, str(v))
 
     #auth_data = f'{BASE_INDENT}auth={parsed_context.auth}'
-    auth_data = "{}auth={}".format(BASE_INDENT,parsed_context.auth)
+    auth_data = "{}auth={}".format(BASE_INDENT, parsed_context.auth)
     proxy_data = "\n{}proxies={}".format(BASE_INDENT, parsed_context.proxy)
 
     formatter = {
@@ -137,4 +144,3 @@ def dict_to_pretty_string(the_dict, indent=4):
 
     return ("\n" + " " * indent).join(
         json.dumps(the_dict, sort_keys=True, indent=indent, separators=(',', ': ')).splitlines())
-

--- a/uncurl/api.py
+++ b/uncurl/api.py
@@ -6,11 +6,10 @@ import shlex
 from collections import OrderedDict, namedtuple
 
 from six.moves import http_cookies as Cookie
-from typing_extensions import override
 
 
 class ModifiedArgumentParser(argparse.ArgumentParser):
-    @override
+    # @override
     def error(self, message):
         raise ValueError(message)
 

--- a/uncurl/argparser.py
+++ b/uncurl/argparser.py
@@ -1,8 +1,0 @@
-import argparse
-from typing_extensions import override
-
-
-class ArgumentParser(argparse.ArgumentParser):
-    @override
-    def error(self, message):
-        raise ValueError(message)

--- a/uncurl/argparser.py
+++ b/uncurl/argparser.py
@@ -1,0 +1,8 @@
+import argparse
+from typing_extensions import override
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    @override
+    def error(self, message):
+        raise ValueError(message)


### PR DESCRIPTION
Custom ArgumentParser Implementation:

Created a custom ArgumentParser class in uncurl/argparser.py that overrides the error method to raise a ValueError instead of printing error messages and exiting. This change enables easier exception handling and unit testing.